### PR TITLE
Fix/robust observe and deps

### DIFF
--- a/lib/te_aro/active_record_object_tracker.rb
+++ b/lib/te_aro/active_record_object_tracker.rb
@@ -17,7 +17,8 @@ module TeAro
 
       @marshaled_objects_before = current_objects.map { |o| marshal(o) }
       @start_called = true
-      @started_at = DateTime.now
+      # Use Time.now to be consistent with AR Time objects and to avoid mixing DateTime
+      @started_at = Time.now
     end
 
     def stop
@@ -82,9 +83,7 @@ module TeAro
           log_object_id(logger, old)
           old.attributes.each do |attr_name, old_value|
             new_value = new[attr_name]
-            logger.info("\t\t#{attr_name}: #{value_or_nil(old_value)} -> #{value_or_nil(new_value)}") unless attr_equal?(
-              old_value, new_value
-            )
+            logger.info("\t\t#{attr_name}: #{value_or_nil(old_value)} -> #{value_or_nil(new_value)}") unless attr_equal?(old_value, new_value)
           end
         end
 
@@ -217,10 +216,6 @@ module TeAro
         deltas[k] = -before[k] unless deltas.include?(k)
       end
       deltas
-    end
-
-    def ar_to_hash(object)
-      object.as_json.merge('class_name' => object.class.to_s)
     end
 
     def marshal(object)

--- a/lib/te_aro/active_record_object_tracker.rb
+++ b/lib/te_aro/active_record_object_tracker.rb
@@ -34,19 +34,17 @@ module TeAro
     def log_results(logger)
       raise('#start and #stop must be called to obtain results') unless @stop_called
 
+      logger.info('Object counts:')
+
       change_counts = @results[:change_counts]
-
-      logger.info('Observed objects:')
-
       if change_counts.empty?
-        logger.info("\t(No changes)")
-        return
-      end
+        logger.info("\tNo change")
+      else
+        change_counts.each do |class_name, delta|
+          next if delta.zero?
 
-      change_counts.each do |class_name, delta|
-        next if delta.zero?
-
-        logger.info("\t#{class_name}: #{delta}")
+          logger.info("\t#{class_name}: #{delta}")
+        end
       end
 
       new_objects = @results[:new]

--- a/lib/te_aro/observer.rb
+++ b/lib/te_aro/observer.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'active_record'
+require 'fileutils'
+require 'logger'
 
 module TeAro
   class Observer
@@ -16,11 +18,28 @@ module TeAro
       @object_tracker = ActiveRecordObjectTracker.new(targets)
     end
 
+    # Run the provided block while observing ActiveRecord objects.
+    # Guarantees that the tracker is stopped and results are logged even when
+    # the block raises. The original exception (if any) will propagate.
     def observe(&block)
       @object_tracker.start
-      block.call
-      @object_tracker.stop
-      @object_tracker.log_results(@logger)
+      begin
+        yield
+      ensure
+        # Ensure we always attempt to stop the tracker and log results.
+        # Rescue errors during stop/logging so we don't hide the original exception.
+        begin
+          @object_tracker.stop
+        rescue StandardError
+          # intentionally suppressed to avoid masking original errors
+        end
+
+        begin
+          @object_tracker.log_results(@logger)
+        rescue StandardError
+          # intentionally suppressed
+        end
+      end
 
       self
     end
@@ -28,7 +47,11 @@ module TeAro
     private
 
     def create_logger
-      logger = Logger.new('log/te_aro.log')
+      log_path = 'log/te_aro.log'
+      dir = File.dirname(log_path)
+      FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+
+      logger = Logger.new(log_path)
       logger.formatter = proc do |_severity, _datetime, _progname, msg|
         "#{msg}\n"
       end

--- a/te_aro.gemspec
+++ b/te_aro.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activerecord', '>= 4.2'
+
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug'


### PR DESCRIPTION
- Ensure `Observer#observe` always calls `ActiveRecordObjectTracker#stop` and logs results even if the observed block raises an exception. This prevents the tracker from being left in a started state and ensures results are recorded.
- Use `Time.now` in `ActiveRecordObjectTracker#start` to avoid `DateTime`/`Time` mixing when comparing `created_at`/`updated_at` timestamps.
- Add a runtime dependency on `activerecord` so the gem pulls in ActiveRecord when installed.
- Ensure the log directory exists before opening the file logger.
- Log results even if object counts don't change, as there may still be changes to current objects.
- Other minor cleanup.